### PR TITLE
Add read operation APIs for metrics and traces

### DIFF
--- a/aiopslab/observer/metric_api.py
+++ b/aiopslab/observer/metric_api.py
@@ -380,7 +380,18 @@ class PrometheusAPI:
             #     else:
             #         dt.to_csv(file_path, index=False)
             start_time = current_et
-        return f"Metrics data exported to directory: {save_path}"
+            
+        # Print the folder structure
+        export_msg = f"Metrics data exported to directory: {save_path}\n\nFolder structure of exported metrics:\n"
+        for root, dirs, files in os.walk(save_path):
+            level = root.replace(save_path, "").count(os.sep)
+            indent = " " * 4 * level
+            export_msg += f"{indent}{os.path.basename(root)}/\n"  
+            subindent = " " * 4 * (level + 1)
+            for f in files:
+                export_msg += f"{subindent}{f}\n"
+        # print(export_msg)
+        return export_msg
 
     def get_all_metrics(self):
         """Get all of the metrics"""

--- a/aiopslab/orchestrator/actions/base.py
+++ b/aiopslab/orchestrator/actions/base.py
@@ -4,6 +4,7 @@
 """Base class for task actions."""
 
 import os
+import pandas as pd
 from datetime import datetime, timedelta
 from aiopslab.utils.actions import action, read, write
 from aiopslab.service.kubectl import KubeCtl
@@ -96,6 +97,29 @@ class TaskActions:
         )
 
         return save_dir_str
+    
+    @staticmethod
+    @read
+    def read_metrics(file_path: str) -> str:
+        """
+        Reads and returns metrics from a specified CSV file.
+
+        Args:
+            file_path (str): Path to the metrics file (CSV format).
+
+        Returns:
+            str: The requested metrics or an error message.
+        """
+        if not os.path.exists(file_path):
+            return {"error": f"Metrics file '{file_path}' not found."}
+
+        try:
+            df_metrics = pd.read_csv(file_path)
+
+            return df_metrics.to_string(index=False)
+
+        except Exception as e:
+            return f"Failed to read metrics: {str(e)}"
 
     @staticmethod
     @read
@@ -123,6 +147,29 @@ class TaskActions:
 
         return trace_api.save_traces(df_traces, save_path)
         # return f"Trace data exported to: {save_path}"
+
+    @staticmethod
+    @read
+    def read_traces(file_path: str) -> str:
+        """
+        Reads and returns traces from a specified CSV file.
+
+        Args:
+            file_path (str): Path to the traces file (CSV format).
+
+        Returns:
+            str: The requested traces or an error message.
+        """
+        if not os.path.exists(file_path):
+            return {"error": f"Traces file '{file_path}' not found."}
+
+        try:
+            df_traces = pd.read_csv(file_path)
+
+            return df_traces.to_string(index=False)
+
+        except Exception as e:
+            return f"Failed to read traces: {str(e)}"
 
     @staticmethod
     # @read


### PR DESCRIPTION
Read the exported telemetry (traces/metrics) files. 

We need these APIs since the data will be stored on the local machine instead of inside the cluster when doing remote cluster setup.