### PR TITLE
Prolong the Hotel-Reservation deployment time

### DIFF
--- a/aiopslab/service/apps/hotelres.py
+++ b/aiopslab/service/apps/hotelres.py
@@ -68,7 +68,7 @@ class HotelReservation(Application):
         """Deploy the Kubernetes configurations."""
         print(f"Deploying Kubernetes configurations in namespace: {self.namespace}")
         self.kubectl.apply_configs(self.namespace, self.k8s_deploy_path)
-        time.sleep(40)
+        time.sleep(100)
 
     def delete(self):
         """Delete the configmap."""


### PR DESCRIPTION
Hotel-reservation is using kubectl to deploy, where there is no sync mechanism like Helm (Helm will wait the deployment to finish). So I prolong the waiting time to wait longer for the deployment to finish. This is needed especially in the local setup that could be much slower.
