### PR TITLE
Fix bug in chaos yaml file write.

### DIFF
--- a/aiopslab/generators/fault/inject_symp.py
+++ b/aiopslab/generators/fault/inject_symp.py
@@ -31,8 +31,8 @@ class SymptomFaultInjector(FaultInjector):
 
     def create_chaos_experiment(self, experiment_yaml: dict, experiment_name: str):
         chaos_yaml_path = f"/tmp/{experiment_name}.yaml"
-        with open(chaos_yaml_path):
-            yaml.dump(experiment_yaml)
+        with open(chaos_yaml_path, "w") as file:
+            yaml.dump(experiment_yaml, file)
         command = f"kubectl apply -f {chaos_yaml_path}"
         result = self.kubectl.exec_command(command)
         print(f"Applied {experiment_name} chaos experiment: {result}")


### PR DESCRIPTION
The issue was that when we went to write the yaml file for chaos-mesh, we used open without specifiying that we wanted to write (the default is read), so we would crash since we tried to open a file that didn't exist.