### PR TITLE
Debug the `get_log()` and TiDB deployment

### DIFF
--- a/aiopslab/orchestrator/actions/base.py
+++ b/aiopslab/orchestrator/actions/base.py
@@ -45,7 +45,7 @@ class TaskActions:
         except Exception as e:
             return "Error: Your service/namespace does not exist. Use kubectl to check."
 
-        logs = "\n".join(logs.split("\n")[:10])
+        logs = "\n".join(logs.split("\n"))
 
         return logs
 

--- a/scripts/ansible/tidb/tidb_pv_setup.yml
+++ b/scripts/ansible/tidb/tidb_pv_setup.yml
@@ -165,6 +165,8 @@
   # Step 6: Verify the setup
   - name: Verify Persistent Volumes
     shell: kubectl get pv
+    environment:
+      KUBECONFIG: "{{ kubeconfig_path }}"
     register: pv_output
 
   - debug:


### PR DESCRIPTION
The get_log only retrieves the first ten lines of the microservice logs which may not be enough for the debugging of the agent, so I increase it to output all of the logs of a microservice.

Also, when I deploy the TiDB cluster, I found the k8s user should be added to an action otherwise that action cannot use the correct k8s context.

