### PR TITLE
Add containerd runtime support

### DIFF
--- a/aiopslab/config.yml.example
+++ b/aiopslab/config.yml.example
@@ -2,6 +2,9 @@
 k8s_host: control_node_hostname # Put `localhost` if running on cluster; put `kind` if using kind cluster; put a hostname if managing a remote cluster, e.g., apt035.apt.emulab.net
 k8s_user: your_username
 
+# Container runtime (docker or containerd)
+container_runtime: docker
+
 # ssh key path
 ssh_key_path: ~/.ssh/id_rsa # Replace with your ssh key path
 

--- a/aiopslab/config.yml.example
+++ b/aiopslab/config.yml.example
@@ -2,9 +2,6 @@
 k8s_host: control_node_hostname # Put `localhost` if running on cluster; put `kind` if using kind cluster; put a hostname if managing a remote cluster, e.g., apt035.apt.emulab.net
 k8s_user: your_username
 
-# Container runtime (docker or containerd)
-container_runtime: docker
-
 # ssh key path
 ssh_key_path: ~/.ssh/id_rsa # Replace with your ssh key path
 

--- a/aiopslab/generators/fault/inject_symp.py
+++ b/aiopslab/generators/fault/inject_symp.py
@@ -30,19 +30,17 @@ class SymptomFaultInjector(FaultInjector):
             "version": "2.6.2",
         }
 
-        container_runtime = config.get("container_runtime", "docker")
-        # print("DEBUG: container_runtime", container_runtime)
-        if container_runtime == "docker":
+        container_runtime = self.kubectl.get_container_runtime()
+
+        if "docker" in container_runtime:
             pass
-        elif container_runtime == "containerd":
+        elif "containerd" in container_runtime:
             chaos_configs["extra_args"] = [
                 "--set chaosDaemon.runtime=containerd",
                 "--set chaosDaemon.socketPath=/run/containerd/containerd.sock",
             ]
         else:
             raise ValueError(f"Unsupported container runtime: {container_runtime}")
-        
-        # TODO: Add support for K3s, MicroK8s, and CRI-O
 
         Helm.install(**chaos_configs)
         time.sleep(6)

--- a/aiopslab/generators/fault/inject_symp.py
+++ b/aiopslab/generators/fault/inject_symp.py
@@ -43,8 +43,6 @@ class SymptomFaultInjector(FaultInjector):
             raise ValueError(f"Unsupported container runtime: {container_runtime}")
 
         Helm.install(**chaos_configs)
-        time.sleep(6)
-        # Helm.uninstall(**sn_configs)
 
     def create_chaos_experiment(self, experiment_yaml: dict, experiment_name: str):
         chaos_yaml_path = f"/tmp/{experiment_name}.yaml"

--- a/aiopslab/generators/fault/inject_symp.py
+++ b/aiopslab/generators/fault/inject_symp.py
@@ -11,11 +11,6 @@ from aiopslab.service.helm import Helm
 from aiopslab.service.kubectl import KubeCtl
 from aiopslab.generators.fault.base import FaultInjector
 
-from aiopslab.config import Config
-from aiopslab.paths import BASE_DIR
-
-config = Config(BASE_DIR / "config.yml")
-
 class SymptomFaultInjector(FaultInjector):
     def __init__(self, namespace: str):
         super().__init__(namespace)

--- a/aiopslab/service/helm.py
+++ b/aiopslab/service/helm.py
@@ -18,12 +18,15 @@ class Helm:
             release_name (str): Name of the release
             chart_path (str): Path to the helm chart
             namespace (str): Namespace to install the chart
+            version (str): Version of the chart
+            extra_args (List[str)]: Extra arguments for the helm install command
         """
         print("== Helm Install ==")
         release_name = args.get("release_name")
         chart_path = args.get("chart_path")
         namespace = args.get("namespace")
         version = args.get("version")
+        extra_args = args.get("extra_args")
 
         # Install dependencies for chart before installation
         dependency_command = f"helm dependency update {chart_path}"
@@ -36,6 +39,13 @@ class Helm:
         dependency_output, dependency_error = dependency_process.communicate()
 
         command = f"helm install {release_name} {chart_path} -n {namespace} --create-namespace"
+
+        if version:
+            command += f" --version {version}"
+
+        if extra_args:
+            command += " " + " ".join(extra_args)
+
         process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
         output, error = process.communicate()
 

--- a/aiopslab/service/kubectl.py
+++ b/aiopslab/service/kubectl.py
@@ -34,6 +34,16 @@ class KubeCtl:
         """Retrieve the cluster IP address of a specified service within a namespace."""
         service_info = self.core_v1_api.read_namespaced_service(service_name, namespace)
         return service_info.spec.cluster_ip  # type: ignore
+    
+    def get_container_runtime(self):
+        """
+            Retrieve the container runtime used by the cluster.
+            If the cluster uses multiple container runtimes, the first one found will be returned.
+        """
+        for node in self.core_v1_api.list_node().items:
+            for status in node.status.conditions:
+                if status.type == "Ready" and status.status == "True":
+                    return node.status.node_info.container_runtime_version
 
     def get_pod_name(self, namespace, label_selector):
         """Get the name of the first pod in a namespace that matches a given label selector."""


### PR DESCRIPTION
Chaos Mesh uses docker as container runtime by default. When running container killing problems on Kind, which uses containerd as runtime, Chaos Mesh will not able to kill containers due to the inconsistency.