### PR TITLE
Fix problems of redeployment in the redeploy case

### DIFF
--- a/aiopslab/generators/fault/inject_virtual.py
+++ b/aiopslab/generators/fault/inject_virtual.py
@@ -188,7 +188,7 @@ class VirtualizationFaultInjector(FaultInjector):
             print(f"Removed nodeSelector for service {service} and redeployed.")
 
     # V.5 - redeploy without deleting the PV - only for HotelReservation
-    def inject_redepoly_without_pv(self, app: Application):
+    def inject_redeploy_without_pv(self, app: Application):
         """Inject a fault to delete the namespace without deleting the PV."""
         self.kubectl.delete_namespace(self.namespace)
         print(f"Deleting namespace {self.namespace} without deleting the PV.")

--- a/aiopslab/generators/fault/inject_virtual.py
+++ b/aiopslab/generators/fault/inject_virtual.py
@@ -195,7 +195,7 @@ class VirtualizationFaultInjector(FaultInjector):
         time.sleep(15)
         print(f"Redeploying {self.namespace}.")
         app = type(app)()
-        app.deploy()
+        app.deploy_without_wait()
 
     def recover_redepoly_without_pv(self, app: Application):
         app.cleanup()

--- a/aiopslab/orchestrator/problems/redeploy_without_pv/redeploy_without_pv.py
+++ b/aiopslab/orchestrator/problems/redeploy_without_pv/redeploy_without_pv.py
@@ -37,7 +37,7 @@ class RedeployWithoutPVBaseTask:
 
     def inject_fault(self):
         print("== Fault Injection ==")
-        self.injector.inject_redepoly_without_pv(app=self.app)
+        self.injector.inject_redeploy_without_pv(app=self.app)
         # self.injector._inject(
         #     fault_type="redepoly_without_pv",
         #     app=self.app,

--- a/aiopslab/service/apps/hotelres.py
+++ b/aiopslab/service/apps/hotelres.py
@@ -69,6 +69,14 @@ class HotelReservation(Application):
         print(f"Deploying Kubernetes configurations in namespace: {self.namespace}")
         self.kubectl.apply_configs(self.namespace, self.k8s_deploy_path)
         self.kubectl.wait_for_ready(self.namespace)
+    
+    def deploy_without_wait(self):
+        """Deploy the Kubernetes configurations without waiting for ready."""
+        
+        print(f"Deploying Kubernetes configurations in namespace: {self.namespace}")
+        self.kubectl.apply_configs(self.namespace, self.k8s_deploy_path)
+        print(f"Wating for being stable...")
+        time.sleep(30)
 
     def delete(self):
         """Delete the configmap."""

--- a/aiopslab/service/apps/hotelres.py
+++ b/aiopslab/service/apps/hotelres.py
@@ -75,7 +75,7 @@ class HotelReservation(Application):
         
         print(f"Deploying Kubernetes configurations in namespace: {self.namespace}")
         self.kubectl.apply_configs(self.namespace, self.k8s_deploy_path)
-        print(f"Wating for being stable...")
+        print(f"Waiting for being stable...")
         time.sleep(30)
 
     def delete(self):


### PR DESCRIPTION
In `redeploy_without_PV-detection-1`, my AIOpsLab client stucks at `self.kubectl.wait_for_ready(self.namespace)` in the redeployment phase. This is because some pods get into `CrashLoopBackoff` so these pods will never get into a all-ready state.