### PR TITLE
Handle traces/metrics file not found errors

### DIFF
--- a/aiopslab/orchestrator/orchestrator.py
+++ b/aiopslab/orchestrator/orchestrator.py
@@ -121,8 +121,15 @@ class Orchestrator:
 
         try:
             env_response = self.session.problem.perform_action(api, *args, **kwargs)
+        
+            if hasattr(env_response, "error"):
+                env_response = str(env_response)
+                print("An error occurred:", env_response)
         except InvalidActionError as e:
             env_response = str(e)
+        except Exception as e:
+            env_response = str(e)
+            print("Unhandled exception:", e)
 
         self.session.add({"role": "env", "content": env_response})
 


### PR DESCRIPTION
If pass a nonexistent file to `get_traces` or `get_metrics`, pydantic would raise an exception, like
```
  File "xxx/AIOpsLab/aiopslab/orchestrator/orchestrator.py", line 130, in ask_env
    self.session.add({"role": "env", "content": env_response})
  File "xxx/AIOpsLab/aiopslab/session.py", line 77, in add
    self.history.append(SessionItem.model_validate(item))
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "xxx/.venv/lib/python3.12/site-packages/pydantic/main.py", line 551, in model_validate
    return cls.__pydantic_validator__.validate_python(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for SessionItem
content
  Input should be a valid string [type=string_type, input_value={'error': "Metrics file '...etric.json' not found."}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.7/v/string_type
```