### PR TITLE
Fix the issue of getting log of the workload pod

### DIFF
--- a/aiopslab/orchestrator/actions/base.py
+++ b/aiopslab/orchestrator/actions/base.py
@@ -39,6 +39,8 @@ class TaskActions:
                 user_service_pod = kubectl.get_pod_name(
                     namespace, f"io.kompose.service={service}"
                 )
+            elif namespace == "default" and "wrk2-job" in service:
+                user_service_pod = kubectl.get_pod_name(namespace, f"job-name=wrk2-job")
             else:
                 raise Exception
             logs = kubectl.get_pod_logs(user_service_pod, namespace)


### PR DESCRIPTION
Sometimes the agent will check the workload pod which is in the default namespace. This PR handles that situation instead of raising an exception for it.