### PR TITLE
Fix return value of read operations

### DIFF
--- a/aiopslab/orchestrator/actions/base.py
+++ b/aiopslab/orchestrator/actions/base.py
@@ -113,7 +113,7 @@ class TaskActions:
             str: The requested metrics or an error message.
         """
         if not os.path.exists(file_path):
-            return {"error": f"Metrics file '{file_path}' not found."}
+            return f"error: Metrics file '{file_path}' not found."
 
         try:
             df_metrics = pd.read_csv(file_path)
@@ -163,7 +163,7 @@ class TaskActions:
             str: The requested traces or an error message.
         """
         if not os.path.exists(file_path):
-            return {"error": f"Traces file '{file_path}' not found."}
+            return f"error: Traces file '{file_path}' not found."
 
         try:
             df_traces = pd.read_csv(file_path)


### PR DESCRIPTION
The agent may experience:

```
File "/Users/yinfang/Desktop/xlab-uiuc/xagent/.venv/lib/python3.12/site-packages/pydantic/main.py", line 551, in model_validate
    return cls.__pydantic_validator__.validate_python(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for SessionItem
content
  Input should be a valid string [type=string_type, input_value={'error': "Metrics file '..._total.csv' not found."}, input_type=dict]
```