### PR TITLE
Issue 42 (Cleanup before exit)

### DIFF
--- a/aiopslab/generators/fault/base.py
+++ b/aiopslab/generators/fault/base.py
@@ -59,7 +59,6 @@ class FaultInjector:
             self._invoke_method("recover", fault_type, microservices)
         elif fault_type:
             self._invoke_method("recover", fault_type)
-        time.sleep(6)
 
     def _invoke_method(self, action_prefix, *args):
         """helper: injects/recovers faults based on name"""

--- a/aiopslab/utils/critical_section.py
+++ b/aiopslab/utils/critical_section.py
@@ -1,0 +1,23 @@
+import signal
+
+
+class CriticalSection:
+    def __enter__(self):
+        # Save the original signal handler
+        self.original_handler = signal.signal(signal.SIGINT, self.signal_handler)
+        self.signaled = False
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # If SIGINT was raised during the critical section, handle it after the block
+        if self.signaled:
+            raise KeyboardInterrupt  # Re-raise KeyboardInterrupt to exit
+
+        # Restore the original signal handler
+        signal.signal(signal.SIGINT, self.original_handler)
+        return False  # Do not suppress exceptions
+
+    def signal_handler(self, signum, frame):
+        """Handle SIGINT by just setting a flag to delay it."""
+        self.signaled = True  # Flag that SIGINT occurred
+        print("\nCtrl+C detected! But deferring the effect for consistency...")


### PR DESCRIPTION
Injected faults can lead to failure of starting the app next time when the program exits before fault recovery.

Add codes to ensure the happening of fault recovery before exit if faults have been injected (exceptions or ctrl+c)

time.sleep can incur errors when being used inside a atexit-registered function