### PR TITLE
Fix service names to match actual pods in astronomy shop localization problems.

### DIFF
--- a/aiopslab/orchestrator/problems/ad_service_failure/ad_service_failure.py
+++ b/aiopslab/orchestrator/problems/ad_service_failure/ad_service_failure.py
@@ -16,7 +16,7 @@ class AdServiceFailureBaseTask:
         self.kubectl = KubeCtl()
         self.namespace = self.app.namespace
         self.injector = OtelFaultInjector(namespace=self.namespace)
-        self.faulty_service = "adservice"
+        self.faulty_service = "ad"
 
     def start_workload(self):
         print("== Start Workload ==")

--- a/aiopslab/orchestrator/problems/ad_service_high_cpu/ad_service_high_cpu.py
+++ b/aiopslab/orchestrator/problems/ad_service_high_cpu/ad_service_high_cpu.py
@@ -16,7 +16,7 @@ class AdServiceHighCpuBaseTask:
         self.kubectl = KubeCtl()
         self.namespace = self.app.namespace
         self.injector = OtelFaultInjector(namespace=self.namespace)
-        self.faulty_service = "adservice"
+        self.faulty_service = "ad"
 
     def start_workload(self):
         print("== Start Workload ==")

--- a/aiopslab/orchestrator/problems/ad_service_manual_gc/ad_service_manual_gc.py
+++ b/aiopslab/orchestrator/problems/ad_service_manual_gc/ad_service_manual_gc.py
@@ -16,7 +16,7 @@ class AdServiceManualGcBaseTask:
         self.kubectl = KubeCtl()
         self.namespace = self.app.namespace
         self.injector = OtelFaultInjector(namespace=self.namespace)
-        self.faulty_service = "adservice"
+        self.faulty_service = "ad"
 
     def start_workload(self):
         print("== Start Workload ==")

--- a/aiopslab/orchestrator/problems/cart_service_failure/cart_service_failure.py
+++ b/aiopslab/orchestrator/problems/cart_service_failure/cart_service_failure.py
@@ -16,7 +16,7 @@ class CartServiceFailureBaseTask:
         self.kubectl = KubeCtl()
         self.namespace = self.app.namespace
         self.injector = OtelFaultInjector(namespace=self.namespace)
-        self.faulty_service = "cartservice"
+        self.faulty_service = "cart"
 
     def start_workload(self):
         print("== Start Workload ==")

--- a/aiopslab/orchestrator/problems/payment_service_failure/payment_service_failure.py
+++ b/aiopslab/orchestrator/problems/payment_service_failure/payment_service_failure.py
@@ -16,7 +16,7 @@ class PaymentServiceFailureBaseTask:
         self.kubectl = KubeCtl()
         self.namespace = self.app.namespace
         self.injector = OtelFaultInjector(namespace=self.namespace)
-        self.faulty_service = "paymentservice"
+        self.faulty_service = "payment"
 
     def start_workload(self):
         print("== Start Workload ==")

--- a/aiopslab/orchestrator/problems/payment_service_unreachable/payment_service_unreachable.py
+++ b/aiopslab/orchestrator/problems/payment_service_unreachable/payment_service_unreachable.py
@@ -16,7 +16,7 @@ class PaymentServiceUnreachableBaseTask:
         self.kubectl = KubeCtl()
         self.namespace = self.app.namespace
         self.injector = OtelFaultInjector(namespace=self.namespace)
-        self.faulty_service = "paymentservice"
+        self.faulty_service = "checkout"
 
     def start_workload(self):
         print("== Start Workload ==")

--- a/aiopslab/orchestrator/problems/product_catalog_failure/product_catalog_failure.py
+++ b/aiopslab/orchestrator/problems/product_catalog_failure/product_catalog_failure.py
@@ -16,7 +16,7 @@ class ProductCatalogServiceFailureBaseTask:
         self.kubectl = KubeCtl()
         self.namespace = self.app.namespace
         self.injector = OtelFaultInjector(namespace=self.namespace)
-        self.faulty_service = "productcatalogservice"
+        self.faulty_service = "product-catalog"
 
     def start_workload(self):
         print("== Start Workload ==")

--- a/aiopslab/orchestrator/problems/recommendation_service_cache_failure/recommendation_service_cache_failure.py
+++ b/aiopslab/orchestrator/problems/recommendation_service_cache_failure/recommendation_service_cache_failure.py
@@ -16,7 +16,7 @@ class RecommendationServiceCacheFailureBaseTask:
         self.kubectl = KubeCtl()
         self.namespace = self.app.namespace
         self.injector = OtelFaultInjector(namespace=self.namespace)
-        self.faulty_service = "recommendationservice"
+        self.faulty_service = "recommendation"
 
     def start_workload(self):
         print("== Start Workload ==")


### PR DESCRIPTION
The pod names in astronomy shop don't match the feature flag documentation. The localization problems have been updated such that `faulty_service` matches the actual pod name of the service.