### PR TITLE
Update arch check to use node arch and not local arch

### DIFF
--- a/aiopslab/service/apps/socialnet.py
+++ b/aiopslab/service/apps/socialnet.py
@@ -3,8 +3,6 @@
 
 """Interface to the social network application from DeathStarBench"""
 
-import platform
-
 from aiopslab.service.helm import Helm
 from aiopslab.service.kubectl import KubeCtl
 from aiopslab.service.apps.base import Application
@@ -22,8 +20,6 @@ class SocialNetwork(Application):
         )
         self.create_namespace()
         self.create_tls_secret()
-        # Detect CPU architecture, we need to deploy media-frontend differently on arm
-        self.is_arm = platform.machine().lower() in ["arm64", "aarch64"]
 
     def load_app_json(self):
         super().load_app_json()
@@ -47,15 +43,22 @@ class SocialNetwork(Application):
             print("TLS secret already exists. Skipping creation.")
 
     def deploy(self):
-        """Deploy the Helm configurations."""
-        if self.is_arm:
-            # Update image to use arm build image
+        """Deploy the Helm configurations with architecture-aware image selection."""
+        node_architectures = self.kubectl.get_node_architectures()
+        is_arm = any(arch in ["arm64", "aarch64"] for arch in node_architectures)
+
+        if is_arm:
+            # Use the ARM-compatible image for media-frontend
             if "extra_args" not in self.helm_configs:
                 self.helm_configs["extra_args"] = []
-            
-            self.helm_configs["extra_args"].append("--set media-frontend.container.image=jacksonarthurclark/media-frontend")
-            self.helm_configs["extra_args"].append("--set media-frontend.container.imageVersion=latest")
-        
+
+            self.helm_configs["extra_args"].append(
+                "--set media-frontend.container.image=jacksonarthurclark/media-frontend"
+            )
+            self.helm_configs["extra_args"].append(
+                "--set media-frontend.container.imageVersion=latest"
+            )
+
         Helm.install(**self.helm_configs)
         Helm.assert_if_deployed(self.helm_configs["namespace"])
 

--- a/aiopslab/service/kubectl.py
+++ b/aiopslab/service/kubectl.py
@@ -269,6 +269,17 @@ class KubeCtl:
         # else:
         #     return out.stdout.decode("utf-8")
 
+    def get_node_architectures(self):
+        """Return a set of CPU architectures from all nodes in the cluster."""
+        architectures = set()
+        try:
+            nodes = self.core_v1_api.list_node()
+            for node in nodes.items:
+                arch = node.status.node_info.architecture
+                architectures.add(arch)
+        except ApiException as e:
+            print(f"Exception when retrieving node architectures: {e}\n")
+        return architectures
 
 # Example usage:
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #61 

There's a bug using a remote cluster since we check for CPU architecture locally instead of on the cluster. So, if you deploy from MacOS running arm, `is_arm` would be true 
despite the remote cluster running amd64.

I've updated the arm check to check on the node, tested on both kind and cloudlab to validate.