### PR TITLE
hotfix: Fix revoke_auth localization oracle

### DIFF
--- a/aiopslab/orchestrator/problems/revoke_auth/revoke_auth.py
+++ b/aiopslab/orchestrator/problems/revoke_auth/revoke_auth.py
@@ -98,7 +98,8 @@ class MongoDBRevokeAuthLocalization(MongoDBRevokeAuthBaseTask, LocalizationTask)
             return self.results
 
         # Calculate exact match and subset
-        is_exact = is_exact_match(soln, self.faulty_service)
+        is_exact = is_exact_match(soln, self.faulty_service) or is_exact_match(soln, self.faulty_service.removeprefix("mongodb-")) # Given that monogodb-geo and geo are closely coupled
+                                                                                                                                   # (likewise with rate), either pod should be an answer
         is_sub = is_subset([self.faulty_service], soln)
 
         # Determine accuracy


### PR DESCRIPTION
It now considsers the pod names to be answers as well, which makes sense give that they're closely coupled