### PR TITLE
Oracle polls pod status for 1 minute to handle k8s restart policy

### DIFF
--- a/aiopslab/orchestrator/problems/misconfig_app/misconfig_app_hotel_res.py
+++ b/aiopslab/orchestrator/problems/misconfig_app/misconfig_app_hotel_res.py
@@ -3,6 +3,7 @@
 
 """MongoDB storage user unregistered problem in the HotelReservation application."""
 
+from time import sleep
 from typing import Any
 
 from aiopslab.orchestrator.tasks import *
@@ -166,26 +167,32 @@ class MisconfigAppHotelResMitigation(MisconfigAppHotelResBaseTask, MitigationTas
         super().eval(soln, trace, duration)
 
         # Check if all services (not only faulty service) is back to normal (Running)
-        pod_list = self.kubectl.list_pods(self.namespace)
         all_normal = True
-
-        for pod in pod_list.items:
-            # Check container statuses
-            for container_status in pod.status.container_statuses:
-                if container_status.state.waiting:
-                    reason = container_status.state.waiting.reason
-                    if reason in ["CrashLoopBackOff", "Error", "ImagePullBackOff", "ErrImagePull"]:
-                        print(f"Container {container_status.name} is in error state: {reason}")
+        # Check twice to reduce false positives due to pod restart
+        for _ in range(2):
+            pod_list = self.kubectl.list_pods(self.namespace)
+            for pod in pod_list.items:
+                # Check container statuses
+                for container_status in pod.status.container_statuses:
+                    if container_status.state.waiting:
+                        reason = container_status.state.waiting.reason
+                        if reason in ["CrashLoopBackOff", "Error", "ImagePullBackOff", "ErrImagePull"]:
+                            print(f"Container {container_status.name} is in error state: {reason}")
+                            all_normal = False
+                    elif container_status.state.terminated and container_status.state.terminated.reason != "Completed":
+                        print(f"Container {container_status.name} is terminated with reason: {container_status.state.terminated.reason}")
                         all_normal = False
-                elif container_status.state.terminated and container_status.state.terminated.reason != "Completed":
-                    print(f"Container {container_status.name} is terminated with reason: {container_status.state.terminated.reason}")
-                    all_normal = False
-                elif not container_status.ready:
-                    print(f"Container {container_status.name} is not ready")
-                    all_normal = False
+                    elif not container_status.ready:
+                        print(f"Container {container_status.name} is not ready")
+                        all_normal = False
+
+                if not all_normal:
+                    break
 
             if not all_normal:
                 break
+            # Wait for 5 seconds before checking again
+            sleep(5) 
 
         self.results["success"] = all_normal
         return self.results

--- a/aiopslab/orchestrator/problems/misconfig_app/misconfig_app_hotel_res.py
+++ b/aiopslab/orchestrator/problems/misconfig_app/misconfig_app_hotel_res.py
@@ -168,8 +168,8 @@ class MisconfigAppHotelResMitigation(MisconfigAppHotelResBaseTask, MitigationTas
 
         # Check if all services (not only faulty service) is back to normal (Running)
         all_normal = True
-        # Check twice to reduce false positives due to pod restart
-        for _ in range(2):
+        # Polling for 1 minute to check if all services are back to normal
+        for _ in range(12): # 5 seconds interval, 12 times, total 1 minute
             pod_list = self.kubectl.list_pods(self.namespace)
             for pod in pod_list.items:
                 # Check container statuses

--- a/clients/gpt.py
+++ b/clients/gpt.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     orchestrator = Orchestrator()
     orchestrator.register_agent(agent, name="gpt-w-shell")
 
-    pid = "misconfig_app_hotel_res-mitigation-1"
+    pid = "scale_pod_zero_social_net-mitigation-1"
     problem_desc, instructs, apis = orchestrator.init_problem(pid)
     agent.init_context(problem_desc, instructs, apis)
     asyncio.run(orchestrator.start_problem(max_steps=10))


### PR DESCRIPTION
#75 helped to check all potential error states that a pod may experience. However, another edge case might happen due to pod's [restart policy](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy), which is Always by default. 

Please see example run: [5ad96155-e668-4b05-a95c-cfd42c23b71d_1746310434.4067025.json](https://github.com/user-attachments/files/20025508/5ad96155-e668-4b05-a95c-cfd42c23b71d_1746310434.4067025.json)